### PR TITLE
Domain type improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Usage
     ("cl-tld")
     CL-USER> (cl-tld:get-tld "www.shellcodes.org")
     "org"
+    :ICANN
     CL-USER> (cl-tld:get-domain-suffix "www.shellcodes.org")
     "shellcodes.org"
-
+    :ICANN
+    CL-USER> (cl-tld:get-domain-suffix "load-balancer.pvt")
+    "load-balancer.pvt"
+    :UNMANAGED

--- a/cl-tld.lisp
+++ b/cl-tld.lisp
@@ -7,16 +7,19 @@
 (defvar *tld-data* (make-hash-table :test #'equal))
 (defvar *tld-data-path* (asdf:system-relative-pathname 'cl-tld "effective_tld_names.dat"))
 
-(defun add-domain-name (domain-name)
-  (setf (gethash domain-name *tld-data*) domain-name))
+(defun add-domain-name (domain-name &optional (type :unmanaged))
+  (setf (gethash domain-name *tld-data*) type))
 
 (defun load-data ()
   (with-open-file (stream *tld-data-path*)
     (loop for line = (read-line stream nil)
+          with icann = :icann
           while line
+          when (string= line "// ===BEGIN PRIVATE DOMAINS===")
+            do (setf icann :private)
           when (and (string/= line "")
                     (string/= line "//" :end1 2))
-            do (add-domain-name line))))
+            do (add-domain-name line icann))))
 
 (load-data)
 
@@ -35,14 +38,20 @@
   (format nil "~{~A~^.~}" domain-item-list))
 
 (defun get-domain-tld (domain-item-list)
-  (dotimes (i (length domain-item-list))
-    (let* ((domain-item (join-domain (subseq domain-item-list i)))
-           (tld domain-item)
-           (tld-* (concatenate 'string "*." domain-item))
-           (tld-! (concatenate 'string "!" domain-item)))
-      (cond ((get-tld-data tld) (return domain-item))
-            ((get-tld-data tld-!) (return (join-domain (rest (subseq domain-item-list i)))))
-            ((get-tld-data tld-*) (return (join-domain (subseq domain-item-list (- i 1)))))))))
+  (let ((length (length domain-item-list)))
+   (dotimes (i length)
+     (let* ((num-parts (- length i))
+            (domain-item (join-domain (subseq domain-item-list i)))
+            (tld domain-item)
+            (tld-* (concatenate 'string "*." domain-item))
+            (tld-! (concatenate 'string "!" domain-item)))
+       (cond ((get-tld-data tld) (return (values domain-item
+                                                 (get-tld-data tld))))
+             ((get-tld-data tld-!) (return (values (join-domain (rest (subseq domain-item-list i)))
+                                                   (get-tld-data tld-!))))
+             ((get-tld-data tld-*) (return (values (join-domain (subseq domain-item-list (- i 1)))
+                                                   (get-tld-data tld-*))))
+             ((= 1 num-parts) (return (values domain-item :unmanaged))))))))
 
 (defun is-domain-p (domain)
   (position #\. domain))
@@ -55,13 +64,15 @@
 (defun get-domain-suffix (domain)
   (if (not (is-domain-p domain))
       (error "not is a domain")
-      (let* ((domain-item-list (string-split domain #\.))
-             (domain-tld (get-domain-tld domain-item-list))
-             (dot-count (count #\. domain-tld)))
-        (concatenate 'string
-                     (nth (- (length domain-item-list)
-                             (1+ dot-count)
-                             1)
-                          domain-item-list)
-                     "."
-                     domain-tld))))
+      (let ((domain-item-list (string-split domain #\.)))
+        (multiple-value-bind (domain-tld type) (get-domain-tld domain-item-list)
+          (let ((dot-count (count #\. domain-tld)))
+            (values
+             (concatenate 'string
+                          (nth (- (length domain-item-list)
+                                  (1+ dot-count)
+                                  1)
+                               domain-item-list)
+                          "."
+                          domain-tld)
+             type))))))

--- a/cl-tld.lisp
+++ b/cl-tld.lisp
@@ -57,22 +57,24 @@
   (position #\. domain))
 
 (defun get-tld (domain)
-  (if (not (is-domain-p domain))
-      (error "not is a domain")
+  (if (string= "" domain)
+      (error (format nil "\"~a\" is not a TLD." domain))
       (get-domain-tld (string-split domain #\.))))
 
 (defun get-domain-suffix (domain)
   (if (not (is-domain-p domain))
-      (error "not is a domain")
+      (error (format nil "\"~a\" is not a domain." domain))
       (let ((domain-item-list (string-split domain #\.)))
         (multiple-value-bind (domain-tld type) (get-domain-tld domain-item-list)
-          (let ((dot-count (count #\. domain-tld)))
-            (values
-             (concatenate 'string
-                          (nth (- (length domain-item-list)
-                                  (1+ dot-count)
-                                  1)
-                               domain-item-list)
-                          "."
-                          domain-tld)
-             type))))))
+          (if (string= domain-tld domain)
+              (error (format nil "\"~a\" is private TLD, not a registerable domain." domain))
+              (let ((dot-count (count #\. domain-tld)))
+                (values
+                 (concatenate 'string
+                              (nth (- (length domain-item-list)
+                                      (1+ dot-count)
+                                      1)
+                                   domain-item-list)
+                              "."
+                              domain-tld)
+                 type)))))))

--- a/test.lisp
+++ b/test.lisp
@@ -11,5 +11,7 @@
   (assert (string= (get-domain-suffix "xx.www.ck") "www.ck"))
   (assert (string= (get-domain-suffix "www.lx.mm") "www.lx.mm"))
   (assert (string= (get-domain-suffix "city.kitakyushu.jp") "city.kitakyushu.jp"))
-  (add-domain-name "localhost")
-  (assert (string= (get-tld "lx.localhost") "localhost")))
+
+  ;; TLDs not present in the PSL are considered :UNMANAGED
+  (assert (string= (get-tld "lx.localhost") "localhost"))
+  (assert (eq (nth-value 1 (get-tld "lx.localhost")) :unmanaged)))

--- a/test.lisp
+++ b/test.lisp
@@ -13,5 +13,17 @@
   (assert (string= (get-domain-suffix "city.kitakyushu.jp") "city.kitakyushu.jp"))
 
   ;; TLDs not present in the PSL are considered :UNMANAGED
-  (assert (string= (get-tld "lx.localhost") "localhost"))
-  (assert (eq (nth-value 1 (get-tld "lx.localhost")) :unmanaged)))
+  (multiple-value-bind (tld type) (get-tld "lx.localhost")
+    (assert (string= tld "localhost"))
+    (assert (eq type :unmanaged)))
+
+  (multiple-value-bind (tld type) (get-tld "com")
+    (assert (string= tld "com"))
+    (assert (eq type :icann)))
+
+  ;; Even though this domain has a #\., it's for a private TLD without a
+  ;; registerable domain part.
+  (eq nil (ignore-errors (get-domain-suffix "co.krd")))
+  (eq nil (ignore-errors (get-domain-suffix "com")))
+  (eq nil (ignore-errors (get-domain-suffix "")))
+  (eq nil (ignore-errors (get-tld ""))))


### PR DESCRIPTION
This PR makes two improvements:

`GET-TLD` and `GET-DOMAIN-SUFFIX` now return `(VALUES DOMAIN TYPE)` where `TYPE` is one of `:ICANN`, `:PRIVATE`, or `:UNMANAGED`. For some use cases, you will handle these types of domains differently. Since they are returned as the second value, it shouldn't break backwards compatibility in most cases. Rather than having to manually add TLDs as you did with the `localhost` example in your tests, things will Just Work when presented with a domain name that doesn't use a PSL-recognized TLD, with the helpful additional information that it is unmanaged. Users could still add TLDs with another type (e.g., `:INTERNAL`) as a way of differentiating their internally managed TLDs and those managed by ICANN.

`GET-TLD` used to fail when provided `"com"`, even though it is a valid TLD. Now you can check if a TLD is valid with `GET-TLD` and ensuring the second value is not `:UNMANAGED`, which has its uses.

This will cause issues with code that assumes anything without a `.` cannot be a valid TLD, or that previously assumed unmanaged domains to be invalid, but I think it's an improvement, especially when prior code encountered an unmanaged TLD. So this:

```
CL-TLD> (get-domain-suffix "foo.banana.faketld")
"banana."
```

, which was a tad confusing becomes the more helpful:

```
CL-TLD> (get-domain-suffix "foo.banana.faketld")
"banana.faketld"
:UNMANAGED
```

I added some additional tests to make the changes more apparent.

Thanks for the library! I was about to write this myself when I figured I should search first to make sure no one else hadn't already done the work :). Also, I'm not sure what the process is like to update Quicklisp, but I'm happy to handle that once I figure it out since I'd like to try and get [a package of mine](https://github.com/ynadji/netaddr) added myself.